### PR TITLE
Supports quoted keys in properties

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## HEAD
+* Supports quoted keys in resources.
+
 ## 0.1.2
 * Better support for inherited scenes
 

--- a/godot_parser/structure.py
+++ b/godot_parser/structure.py
@@ -4,6 +4,7 @@ from pyparsing import (
     Empty,
     Group,
     Optional,
+    QuotedString,
     Suppress,
     Word,
     alphanums,
@@ -14,7 +15,10 @@ from pyparsing import (
 from .sections import GDSection, GDSectionHeader
 from .values import value
 
-key = Word(alphanums + "_/").setName("key")
+key = (
+    QuotedString('"', escChar="\\", multiline=False).setName("key") 
+    | Word(alphanums + "_/").setName("key")
+)
 var = Word(alphanums + "_").setName("variable")
 attribute = Group(var + Suppress("=") + value)
 


### PR DESCRIPTION
Some properties can have spaces in their names. In this case Godot quotes them.

This is an example of such situation:

```
[node name="AnimationPlayer" type="AnimationPlayer" parent="Scene/TestDevel/Zone1/TestAnim"]
autoplay = "Test"
playback_process_mode = 0
anims/Test = SubResource( 66 )
"anims/Test 2" = SubResource( 67 )
```

This pull request modifies the parser definition to add support quoted keys.