### PR TITLE
Supports trailing commas in list definitions.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## HEAD
+* Supports trailing commas in list definitions.
 * Supports quoted keys in resources.
 
 ## 0.1.2

--- a/godot_parser/values.py
+++ b/godot_parser/values.py
@@ -41,9 +41,10 @@ obj_type = (
     + Suppress(")")
 ).setParseAction(GDObject.from_parser)
 
-# [ 1, 2 ]
+# [ 1, 2 ] or [ 1, 2, ]
 list_ = (
-    Group(Suppress("[") + Optional(delimitedList(value)) + Suppress("]"))
+    Group(Suppress("[") + Optional(delimitedList(value))
+          + Optional(Suppress(",")) + Suppress("]"))
     .setName("list")
     .setParseAction(lambda p: p.asList())
 )


### PR DESCRIPTION
Apparently, lists can include a trailing comma (at least lists in the section header).

This is an example, in the section header:

```
[node name="Pit Water Trigger" type="Area2D" parent="Scene/Trial1/Acid Pit" groups=[
"WaterBody",
]]
visible = false
position = Vector2( -8.50171, -130.333 )
collision_layer = 256
collision_mask = 2147483649
script = ExtResource( 20 )
__meta__ = {
"_edit_group_": true
}
```

Note how the `groups` attribute is a list which contains newlines and a trailing separator (a comma). Newlines are not a problem for the parser but the comma was not supported.

This pull request modifies the parser definition to add support for trailing commas in list values.
