### PR TITLE
Add groups to node section

### DIFF
--- a/godot_parser/files.py
+++ b/godot_parser/files.py
@@ -190,14 +190,14 @@ class GDFile(object):
         return section
 
     def add_node(
-        self, name: str, type: str = None, parent: str = None, index: int = None
+        self, name: str, type: str = None, parent: str = None, index: int = None, instance: int = None, groups: List[str] = None
     ) -> GDNodeSection:
         """
         Simple API for adding a node
 
         For a friendlier, tree-oriented API use use_tree()
         """
-        node = GDNodeSection(name, type=type, parent=parent, index=index)
+        node = GDNodeSection(name, type=type, parent=parent, index=index, instance=instance, groups=groups)
         self.add_section(node)
         return node
 

--- a/godot_parser/files.py
+++ b/godot_parser/files.py
@@ -43,11 +43,11 @@ GDFileType = TypeVar("GDFileType", bound="GDFile")
 
 
 class GodotFileException(Exception):
-    """ Thrown when there are errors in a Godot file """
+    """Thrown when there are errors in a Godot file"""
 
 
 class GDFile(object):
-    """ Base class representing the contents of a Godot file """
+    """Base class representing the contents of a Godot file"""
 
     project_root: Optional[str] = None
 
@@ -55,7 +55,7 @@ class GDFile(object):
         self._sections = list(sections)
 
     def add_section(self, new_section: GDSection) -> int:
-        """ Add a section to the file and return the index of that section """
+        """Add a section to the file and return the index of that section"""
         new_idx = SCENE_ORDER.index(new_section.header.name)
         for i, section in enumerate(self._sections):
             idx = SCENE_ORDER.index(section.header.name)
@@ -66,7 +66,7 @@ class GDFile(object):
         return len(self._sections) - 1
 
     def remove_section(self, section: GDSection) -> bool:
-        """ Remove a section from the file """
+        """Remove a section from the file"""
         idx = -1
         for i, s in enumerate(self._sections):
             if section == s:
@@ -78,31 +78,31 @@ class GDFile(object):
         return True
 
     def remove_at(self, index: int) -> GDSection:
-        """ Remove a section at an index """
+        """Remove a section at an index"""
         return self._sections.pop(index)
 
     def get_sections(self, name: str = None) -> List[GDSection]:
-        """ Get all sections, or all sections of a given type """
+        """Get all sections, or all sections of a given type"""
         if name is None:
             return self._sections
         return [s for s in self._sections if s.header.name == name]
 
     def get_nodes(self) -> List[GDNodeSection]:
-        """ Get all [node] sections """
+        """Get all [node] sections"""
         return cast(List[GDNodeSection], self.get_sections("node"))
 
     def get_ext_resources(self) -> List[GDExtResourceSection]:
-        """ Get all [ext_resource] sections """
+        """Get all [ext_resource] sections"""
         return cast(List[GDExtResourceSection], self.get_sections("ext_resource"))
 
     def get_sub_resources(self) -> List[GDSubResourceSection]:
-        """ Get all [sub_resource] sections """
+        """Get all [sub_resource] sections"""
         return cast(List[GDSubResourceSection], self.get_sections("sub_resource"))
 
     def find_node(
         self, property_constraints: Optional[dict] = None, **constraints
     ) -> Optional[GDNodeSection]:
-        """ Find first [node] section that matches (see find_section) """
+        """Find first [node] section that matches (see find_section)"""
         return cast(
             GDNodeSection,
             self.find_section("node", property_constraints, **constraints),
@@ -111,7 +111,7 @@ class GDFile(object):
     def find_ext_resource(
         self, property_constraints: Optional[dict] = None, **constraints
     ) -> Optional[GDExtResourceSection]:
-        """ Find first [ext_resource] section that matches (see find_section) """
+        """Find first [ext_resource] section that matches (see find_section)"""
         return cast(
             GDExtResourceSection,
             self.find_section("ext_resource", property_constraints, **constraints),
@@ -120,7 +120,7 @@ class GDFile(object):
     def find_sub_resource(
         self, property_constraints: Optional[dict] = None, **constraints
     ) -> Optional[GDSubResourceSection]:
-        """ Find first [sub_resource] section that matches (see find_section) """
+        """Find first [sub_resource] section that matches (see find_section)"""
         return cast(
             GDSubResourceSection,
             self.find_section("sub_resource", property_constraints, **constraints),
@@ -157,7 +157,7 @@ class GDFile(object):
         property_constraints: Optional[dict] = None,
         **constraints
     ) -> Iterable[GDSection]:
-        """ Same as find_section, but returns all matches """
+        """Same as find_section, but returns all matches"""
         for section in self.get_sections(section_name_):
             found = True
             for k, v in constraints.items():
@@ -176,28 +176,41 @@ class GDFile(object):
                 yield section
 
     def add_ext_resource(self, path: str, type: str) -> GDExtResourceSection:
-        """ Add an ext_resource """
+        """Add an ext_resource"""
         next_id = 1 + max([s.id for s in self.get_ext_resources()] + [0])
         section = GDExtResourceSection(path, type, next_id)
         self.add_section(section)
         return section
 
     def add_sub_resource(self, type: str, **kwargs) -> GDSubResourceSection:
-        """ Add a sub_resource """
+        """Add a sub_resource"""
         next_id = 1 + max([s.id for s in self.get_sub_resources()] + [0])
         section = GDSubResourceSection(type, next_id, **kwargs)
         self.add_section(section)
         return section
 
     def add_node(
-        self, name: str, type: str = None, parent: str = None, index: int = None, instance: int = None, groups: List[str] = None
+        self,
+        name: str,
+        type: str = None,
+        parent: str = None,
+        index: int = None,
+        instance: int = None,
+        groups: List[str] = None,
     ) -> GDNodeSection:
         """
         Simple API for adding a node
 
         For a friendlier, tree-oriented API use use_tree()
         """
-        node = GDNodeSection(name, type=type, parent=parent, index=index, instance=instance, groups=groups)
+        node = GDNodeSection(
+            name,
+            type=type,
+            parent=parent,
+            index=index,
+            instance=instance,
+            groups=groups,
+        )
         self.add_section(node)
         return node
 
@@ -277,7 +290,7 @@ class GDFile(object):
         self._sections[i + 1 : i + 1] = nodes[1:]
 
     def get_node(self, path: str = ".") -> Optional[GDNodeSection]:
-        """ Mimics the Godot get_node API """
+        """Mimics the Godot get_node API"""
         with self.use_tree() as tree:
             if tree.root is None:
                 return None
@@ -286,7 +299,7 @@ class GDFile(object):
 
     @classmethod
     def parse(cls: Type[GDFileType], contents: str) -> GDFileType:
-        """ Parse the contents of a Godot file """
+        """Parse the contents of a Godot file"""
         return cls.from_parser(scene_file.parseString(contents, parseAll=True))
 
     @classmethod
@@ -310,7 +323,7 @@ class GDFile(object):
         return cls(*parse_result)
 
     def write(self, filename: str):
-        """ Writes this to a file """
+        """Writes this to a file"""
         os.makedirs(os.path.dirname(filename), exist_ok=True)
         with open(filename, "w") as ofile:
             ofile.write(str(self))
@@ -331,7 +344,7 @@ class GDFile(object):
 
 
 class GDCommonFile(GDFile):
-    """ Base class with common application logic for all Godot file types """
+    """Base class with common application logic for all Godot file types"""
 
     def __init__(self, name: str, *sections: GDSection) -> None:
         super().__init__(
@@ -379,7 +392,7 @@ class GDCommonFile(GDFile):
                 self.remove_section(s)
 
     def renumber_resource_ids(self):
-        """ Refactor all resource IDs to be sequential with no gaps """
+        """Refactor all resource IDs to be sequential with no gaps"""
         self._renumber_resource_ids(self.get_ext_resources(), ExtResource)
         self._renumber_resource_ids(self.get_sub_resources(), SubResource)
 

--- a/godot_parser/objects.py
+++ b/godot_parser/objects.py
@@ -84,22 +84,22 @@ class Vector2(GDObject):
 
     @property
     def x(self) -> float:
-        """ Getter for x """
+        """Getter for x"""
         return self.args[0]
 
     @x.setter
     def x(self, x: float) -> None:
-        """ Setter for x """
+        """Setter for x"""
         self.args[0] = x
 
     @property
     def y(self) -> float:
-        """ Getter for y """
+        """Getter for y"""
         return self.args[1]
 
     @y.setter
     def y(self, y: float) -> None:
-        """ Setter for y """
+        """Setter for y"""
         self.args[1] = y
 
 
@@ -115,32 +115,32 @@ class Vector3(GDObject):
 
     @property
     def x(self) -> float:
-        """ Getter for x """
+        """Getter for x"""
         return self.args[0]
 
     @x.setter
     def x(self, x: float) -> None:
-        """ Setter for x """
+        """Setter for x"""
         self.args[0] = x
 
     @property
     def y(self) -> float:
-        """ Getter for y """
+        """Getter for y"""
         return self.args[1]
 
     @y.setter
     def y(self, y: float) -> None:
-        """ Setter for y """
+        """Setter for y"""
         self.args[1] = y
 
     @property
     def z(self) -> float:
-        """ Getter for z """
+        """Getter for z"""
         return self.args[2]
 
     @z.setter
     def z(self, z: float) -> None:
-        """ Setter for z """
+        """Setter for z"""
         self.args[2] = z
 
 
@@ -160,42 +160,42 @@ class Color(GDObject):
 
     @property
     def r(self) -> float:
-        """ Getter for r """
+        """Getter for r"""
         return self.args[0]
 
     @r.setter
     def r(self, r: float) -> None:
-        """ Setter for r """
+        """Setter for r"""
         self.args[0] = r
 
     @property
     def g(self) -> float:
-        """ Getter for g """
+        """Getter for g"""
         return self.args[1]
 
     @g.setter
     def g(self, g: float) -> None:
-        """ Setter for g """
+        """Setter for g"""
         self.args[1] = g
 
     @property
     def b(self) -> float:
-        """ Getter for b """
+        """Getter for b"""
         return self.args[2]
 
     @b.setter
     def b(self, b: float) -> None:
-        """ Setter for b """
+        """Setter for b"""
         self.args[2] = b
 
     @property
     def a(self) -> float:
-        """ Getter for a """
+        """Getter for a"""
         return self.args[3]
 
     @a.setter
     def a(self, a: float) -> None:
-        """ Setter for a """
+        """Setter for a"""
         self.args[3] = a
 
 
@@ -205,12 +205,12 @@ class NodePath(GDObject):
 
     @property
     def path(self) -> str:
-        """ Getter for path """
+        """Getter for path"""
         return self.args[0]
 
     @path.setter
     def path(self, path: str) -> None:
-        """ Setter for path """
+        """Setter for path"""
         self.args[0] = path
 
     def __str__(self) -> str:
@@ -223,12 +223,12 @@ class ExtResource(GDObject):
 
     @property
     def id(self) -> int:
-        """ Getter for id """
+        """Getter for id"""
         return self.args[0]
 
     @id.setter
     def id(self, id: int) -> None:
-        """ Setter for id """
+        """Setter for id"""
         self.args[0] = id
 
 
@@ -238,10 +238,10 @@ class SubResource(GDObject):
 
     @property
     def id(self) -> int:
-        """ Getter for id """
+        """Getter for id"""
         return self.args[0]
 
     @id.setter
     def id(self, id: int) -> None:
-        """ Setter for id """
+        """Setter for id"""
         self.args[0] = id

--- a/godot_parser/sections.py
+++ b/godot_parser/sections.py
@@ -1,6 +1,6 @@
 import re
 from collections import OrderedDict
-from typing import Any, Optional, Type, TypeVar
+from typing import Any, List, Optional, Type, TypeVar
 
 from .objects import ExtResource, SubResource
 from .util import stringify_object
@@ -227,7 +227,8 @@ class GDNodeSection(GDSection):
         parent: str = None,
         instance: int = None,
         index: int = None,
-        # TODO: instance_placeholder, owner, groups are referenced in the docs, but I
+        groups: List[str] = None,
+        # TODO: instance_placeholder, owner are referenced in the docs, but I
         # haven't seen them come up yet in my project
     ):
         kwargs = {
@@ -236,6 +237,7 @@ class GDNodeSection(GDSection):
             "parent": parent,
             "instance": ExtResource(instance) if instance is not None else None,
             "index": str(index) if index is not None else None,
+            "groups": groups,
         }
         super().__init__(
             GDSectionHeader(
@@ -306,7 +308,18 @@ class GDNodeSection(GDSection):
             del self.header["index"]
         else:
             self.header["index"] = str(index)
+    
+    @property
+    def groups(self) -> Optional[List[str]]:
+        return self.header.get("groups")
 
+    @groups.setter
+    def groups(self, groups: Optional[List[str]]) -> None:
+        if groups is None:
+            del self.header["groups"]
+        else:
+            self.header["groups"] = groups
+    
 
 class GDResourceSection(GDSection):
     """ Represents a [resource] section """

--- a/godot_parser/sections.py
+++ b/godot_parser/sections.py
@@ -76,7 +76,7 @@ class GDSectionHeader(object):
 
 
 class GDSectionMeta(type):
-    """ Still trying to be too clever """
+    """Still trying to be too clever"""
 
     def __new__(cls, name, bases, dct):
         x = super().__new__(cls, name, bases, dct)
@@ -156,7 +156,7 @@ class GDSection(metaclass=GDSectionMeta):
 
 
 class GDExtResourceSection(GDSection):
-    """ Section representing an [ext_resource] """
+    """Section representing an [ext_resource]"""
 
     def __init__(self, path: str, type: str, id: int):
         super().__init__(GDSectionHeader("ext_resource", path=path, type=type, id=id))
@@ -191,7 +191,7 @@ class GDExtResourceSection(GDSection):
 
 
 class GDSubResourceSection(GDSection):
-    """ Section representing a [sub_resource] """
+    """Section representing a [sub_resource]"""
 
     def __init__(self, type: str, id: int, **kwargs):
         super().__init__(GDSectionHeader("sub_resource", type=type, id=id), **kwargs)
@@ -218,7 +218,7 @@ class GDSubResourceSection(GDSection):
 
 
 class GDNodeSection(GDSection):
-    """ Section representing a [node] """
+    """Section representing a [node]"""
 
     def __init__(
         self,
@@ -308,7 +308,7 @@ class GDNodeSection(GDSection):
             del self.header["index"]
         else:
             self.header["index"] = str(index)
-    
+
     @property
     def groups(self) -> Optional[List[str]]:
         return self.header.get("groups")
@@ -319,10 +319,10 @@ class GDNodeSection(GDSection):
             del self.header["groups"]
         else:
             self.header["groups"] = groups
-    
+
 
 class GDResourceSection(GDSection):
-    """ Represents a [resource] section """
+    """Represents a [resource] section"""
 
     def __init__(self, **kwargs):
         super().__init__(GDSectionHeader("resource"), **kwargs)

--- a/godot_parser/tree.py
+++ b/godot_parser/tree.py
@@ -10,7 +10,7 @@ SENTINEL = object()
 
 
 class TreeMutationException(Exception):
-    """ Raised when attempting to mutate the tree in an unsupported way """
+    """Raised when attempting to mutate the tree in an unsupported way"""
 
 
 class Node(object):
@@ -137,7 +137,7 @@ class Node(object):
 
     @classmethod
     def from_section(cls, section: GDNodeSection):
-        """ Create a Node from a GDNodeSection """
+        """Create a Node from a GDNodeSection"""
         return cls(
             section.name,
             section.type,
@@ -194,11 +194,11 @@ class Node(object):
         return bool(self.properties)
 
     def get_children(self) -> List["Node"]:
-        """ Get all children of this node """
+        """Get all children of this node"""
         return self._children
 
     def get_child(self, name_or_index: Union[int, str]) -> Optional["Node"]:
-        """ Get a child by name or index """
+        """Get a child by name or index"""
         if isinstance(name_or_index, int):
             return self._children[name_or_index]
         for node in self._children:
@@ -207,7 +207,7 @@ class Node(object):
         return None
 
     def get_node(self, path: str) -> Optional["Node"]:
-        """ Mimics the Godot get_node() behavior """
+        """Mimics the Godot get_node() behavior"""
         if path in (".", ""):
             return self
         pieces = path.split("/")
@@ -217,17 +217,17 @@ class Node(object):
         return child.get_node("/".join(pieces[1:]))
 
     def add_child(self, node: "Node") -> None:
-        """ Add a child to the current node """
+        """Add a child to the current node"""
         self._children.append(node)
         node._parent = self
 
     def insert_child(self, index: int, node: "Node") -> None:
-        """ Add a child to the current node before the specified index """
+        """Add a child to the current node before the specified index"""
         self._children.insert(index, node)
         node._parent = self
 
     def _merge_child(self, section: GDNodeSection) -> None:
-        """ Add a child that may be an inherited node """
+        """Add a child that may be an inherited node"""
         for child in self._children:
             if child.name == section.name:
                 child.section = section
@@ -236,7 +236,7 @@ class Node(object):
         self.add_child(Node.from_section(section))
 
     def remove_from_parent(self) -> None:
-        """ Remove this node from its parent """
+        """Remove this node from its parent"""
         if self.parent is not None:
             self.parent.remove_child(self)
 
@@ -281,20 +281,20 @@ class Node(object):
 
 
 class Tree(object):
-    """ Container for the scene tree """
+    """Container for the scene tree"""
 
     def __init__(self, root: Optional[Node] = None):
         self.root = root
 
     def get_node(self, path: str) -> Optional[Node]:
-        """ Mimics the Godot get_node() behavior """
+        """Mimics the Godot get_node() behavior"""
         if self.root is None:
             return None
         return self.root.get_node(path)
 
     @classmethod
     def build(cls, file: GDFile):
-        """ Build the Tree from a flat list of [node]'s """
+        """Build the Tree from a flat list of [node]'s"""
         tree = cls()
         # Makes assumptions that the nodes are well-ordered
         for section in file.get_nodes():
@@ -314,7 +314,7 @@ class Tree(object):
         return tree
 
     def flatten(self) -> List[GDNodeSection]:
-        """ Flatten the tree back into a list of GDNodeSection """
+        """Flatten the tree back into a list of GDNodeSection"""
         ret: List[GDNodeSection] = []
         if self.root is None:
             return ret

--- a/godot_parser/tree.py
+++ b/godot_parser/tree.py
@@ -31,6 +31,7 @@ class Node(object):
         type: str = None,
         instance: int = None,
         section: GDNodeSection = None,
+        groups: List[str] = None,
         properties: dict = None,
     ):
         self._name = name
@@ -39,6 +40,7 @@ class Node(object):
         self._parent = None
         self._index = None
         self.section = section or GDNodeSection(name)
+        self._groups = groups
         self.properties = (
             OrderedDict() if properties is None else OrderedDict(properties)
         )
@@ -178,6 +180,7 @@ class Node(object):
         self.section.type = self._type
         self.section.parent = path
         self.section.instance = self._instance
+        self.section.groups = self._groups
         self.section.properties = self.properties
         if self._index is not None:
             self.section.index = self._index

--- a/godot_parser/util.py
+++ b/godot_parser/util.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 
 def stringify_object(value):
-    """ Serialize a value to the godot file format """
+    """Serialize a value to the godot file format"""
     if value is None:
         return "null"
     elif isinstance(value, str):

--- a/test_parse_files.py
+++ b/test_parse_files.py
@@ -39,7 +39,7 @@ def _parse_and_test_file(filename: str) -> bool:
 
 
 def main():
-    """ Test the parsing of one tscn file or all files in directory """
+    """Test the parsing of one tscn file or all files in directory"""
     parser = argparse.ArgumentParser(description=main.__doc__)
     parser.add_argument("file_or_dir", help="Parse file or files under this directory")
     args = parser.parse_args()

--- a/tests/test_gdfile.py
+++ b/tests/test_gdfile.py
@@ -6,14 +6,14 @@ from godot_parser import GDFile, GDObject, GDResource, GDResourceSection, GDScen
 
 class TestGDFile(unittest.TestCase):
 
-    """ Tests for GDFile """
+    """Tests for GDFile"""
 
     def test_basic_scene(self):
-        """ Run the parsing test cases """
+        """Run the parsing test cases"""
         self.assertEqual(str(GDScene()), "[gd_scene load_steps=1 format=2]\n")
 
     def test_all_data_types(self):
-        """ Run the parsing test cases """
+        """Run the parsing test cases"""
         res = GDResource()
         res.add_section(
             GDResourceSection(
@@ -36,7 +36,7 @@ empty = null
         )
 
     def test_ext_resource(self):
-        """ Test serializing a scene with an ext_resource """
+        """Test serializing a scene with an ext_resource"""
         scene = GDScene()
         scene.add_ext_resource("res://Other.tscn", "PackedScene")
         self.assertEqual(
@@ -48,7 +48,7 @@ empty = null
         )
 
     def test_sub_resource(self):
-        """ Test serializing a scene with an sub_resource """
+        """Test serializing a scene with an sub_resource"""
         scene = GDScene()
         scene.add_sub_resource("Animation")
         self.assertEqual(
@@ -60,7 +60,7 @@ empty = null
         )
 
     def test_node(self):
-        """ Test serializing a scene with a node """
+        """Test serializing a scene with a node"""
         scene = GDScene()
         scene.add_node("RootNode", type="Node2D")
         scene.add_node("Child", type="Area2D", parent=".")
@@ -75,7 +75,7 @@ empty = null
         )
 
     def test_tree_create(self):
-        """ Test creating a scene with the tree API """
+        """Test creating a scene with the tree API"""
         scene = GDScene()
         with scene.use_tree() as tree:
             tree.root = Node("RootNode", type="Node2D")
@@ -94,7 +94,7 @@ visible = false
         )
 
     def test_tree_deep_create(self):
-        """ Test creating a scene with nested children using the tree API """
+        """Test creating a scene with nested children using the tree API"""
         scene = GDScene()
         with scene.use_tree() as tree:
             tree.root = Node("RootNode", type="Node2D")
@@ -117,7 +117,7 @@ visible = false
         )
 
     def test_remove_section(self):
-        """ Test GDScene.remove_section """
+        """Test GDScene.remove_section"""
         scene = GDFile()
         res = scene.add_ext_resource("res://Other.tscn", "PackedScene")
         result = scene.remove_section(GDResourceSection())
@@ -128,7 +128,7 @@ visible = false
         self.assertEqual(len(scene.get_sections()), 0)
 
     def test_section_ordering(self):
-        """ Sections maintain an ordering """
+        """Sections maintain an ordering"""
         scene = GDScene()
         node = scene.add_node("RootNode")
         scene.add_ext_resource("res://Other.tscn", "PackedScene")
@@ -136,7 +136,7 @@ visible = false
         self.assertEqual(scene.get_sections()[1:], [res, node])
 
     def test_add_ext_node(self):
-        """ Test GDScene.add_ext_node """
+        """Test GDScene.add_ext_node"""
         scene = GDScene()
         res = scene.add_ext_resource("res://Other.tscn", "PackedScene")
         node = scene.add_ext_node("Root", res.id)
@@ -144,7 +144,7 @@ visible = false
         self.assertEqual(node.instance, res.id)
 
     def test_write(self):
-        """ Test writing scene out to a file """
+        """Test writing scene out to a file"""
         scene = GDScene()
         outfile = tempfile.mkstemp()[1]
         scene.write(outfile)
@@ -153,13 +153,13 @@ visible = false
         self.assertEqual(scene, gen_scene)
 
     def test_get_node_none(self):
-        """ get_node() works with no nodes """
+        """get_node() works with no nodes"""
         scene = GDScene()
         n = scene.get_node()
         self.assertIsNone(n)
 
     def test_addremove_ext_res(self):
-        """ Test adding and removing an ext_resource """
+        """Test adding and removing an ext_resource"""
         scene = GDScene()
         res = scene.add_ext_resource("res://Res.tscn", "PackedScene")
         self.assertEqual(res.id, 1)
@@ -183,7 +183,7 @@ visible = false
         self.assertEqual(node["texture_pool"].args[0], s.reference)
 
     def test_remove_unused_resource(self):
-        """ Can remove unused resources """
+        """Can remove unused resources"""
         scene = GDScene()
         res = scene.add_ext_resource("res://Res.tscn", "PackedScene")
         scene.remove_unused_resources()
@@ -191,7 +191,7 @@ visible = false
         self.assertEqual(len(resources), 0)
 
     def test_addremove_sub_res(self):
-        """ Test adding and removing a sub_resource """
+        """Test adding and removing a sub_resource"""
         scene = GDResource()
         res = scene.add_sub_resource("CircleShape2D")
         self.assertEqual(res.id, 1)
@@ -209,7 +209,7 @@ visible = false
         self.assertEqual(resource["shape"], s.reference)
 
     def test_find_constraints(self):
-        """ Test for the find_section constraints """
+        """Test for the find_section constraints"""
         scene = GDScene()
         res1 = scene.add_sub_resource("CircleShape2D", radius=1)
         res2 = scene.add_sub_resource("CircleShape2D", radius=2)
@@ -224,7 +224,7 @@ visible = false
         self.assertEqual(found, [res2])
 
     def test_find_node(self):
-        """ Test GDScene.find_node """
+        """Test GDScene.find_node"""
         scene = GDScene()
         n1 = scene.add_node("Root", "Node")
         n2 = scene.add_node("Child", "Node", parent=".")
@@ -234,7 +234,7 @@ visible = false
         self.assertEqual(node, n2)
 
     def test_file_equality(self):
-        """ Tests for GDFile == GDFile """
+        """Tests for GDFile == GDFile"""
         s1 = GDScene(GDResourceSection())
         s2 = GDScene(GDResourceSection())
         self.assertEqual(s1, s2)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -5,10 +5,10 @@ from godot_parser import Color, ExtResource, NodePath, SubResource, Vector2, Vec
 
 class TestGDObjects(unittest.TestCase):
 
-    """ Tests for GD object wrappers """
+    """Tests for GD object wrappers"""
 
     def test_vector2(self):
-        """ Test for Vector2 """
+        """Test for Vector2"""
         v = Vector2(1, 2)
         self.assertEqual(v[0], 1)
         self.assertEqual(v[1], 2)
@@ -25,7 +25,7 @@ class TestGDObjects(unittest.TestCase):
         self.assertEqual(v[1], 4)
 
     def test_vector3(self):
-        """ Test for Vector3 """
+        """Test for Vector3"""
         v = Vector3(1, 2, 3)
         self.assertEqual(v[0], 1)
         self.assertEqual(v[1], 2)
@@ -48,7 +48,7 @@ class TestGDObjects(unittest.TestCase):
         self.assertEqual(v[2], 5)
 
     def test_color(self):
-        """ Test for Color """
+        """Test for Color"""
         c = Color(0.1, 0.2, 0.3, 0.4)
         self.assertEqual(c[0], 0.1)
         self.assertEqual(c[1], 0.2)
@@ -77,7 +77,7 @@ class TestGDObjects(unittest.TestCase):
         self.assertEqual(c[3], 0.6)
 
     def test_node_path(self):
-        """ Test for NodePath """
+        """Test for NodePath"""
         n = NodePath("../Sibling")
         self.assertEqual(n.path, "../Sibling")
         n.path = "../Other"
@@ -85,7 +85,7 @@ class TestGDObjects(unittest.TestCase):
         self.assertEqual(str(n), 'NodePath("../Other")')
 
     def test_ext_resource(self):
-        """ Test for ExtResource """
+        """Test for ExtResource"""
         r = ExtResource(1)
         self.assertEqual(r.id, 1)
         r.id = 2
@@ -93,7 +93,7 @@ class TestGDObjects(unittest.TestCase):
         self.assertEqual(str(r), "ExtResource( 2 )")
 
     def test_sub_resource(self):
-        """ Test for SubResource """
+        """Test for SubResource"""
         r = SubResource(1)
         self.assertEqual(r.id, 1)
         r.id = 2
@@ -101,7 +101,7 @@ class TestGDObjects(unittest.TestCase):
         self.assertEqual(str(r), "SubResource( 2 )")
 
     def test_dunder(self):
-        """ Test the __magic__ methods on GDObject """
+        """Test the __magic__ methods on GDObject"""
         v = Vector2(1, 2)
         self.assertEqual(repr(v), "Vector2( 1, 2 )")
         v2 = Vector2(1, 2)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -80,12 +80,17 @@ tracks/0/keys = {
         GDFile(GDSection(GDSectionHeader("resource"), **{"0/name": "Sand"})),
     ),
     (
-        """[node name="Label" parent="."]
+        """[node name="Label" parent="." groups=["foo", "bar"]]
 text = "Hello
 "
 """,
         GDFile(
-            GDSection(GDSectionHeader("node", name="Label", parent="."), text="Hello\n")
+            GDSection(
+                GDSectionHeader(
+                    "node", name="Label", parent=".", groups=["foo", "bar"]
+                ),
+                text="Hello\n",
+            )
         ),
     ),
 ]
@@ -93,10 +98,10 @@ text = "Hello
 
 class TestParser(unittest.TestCase):
 
-    """  """
+    """ """
 
     def _run_test(self, string: str, expected):
-        """ Run a set of tests """
+        """Run a set of tests"""
         try:
             parse_result = parse(string)
             if expected == "error":
@@ -119,6 +124,6 @@ class TestParser(unittest.TestCase):
             raise
 
     def test_cases(self):
-        """ Run the parsing test cases """
+        """Run the parsing test cases"""
         for string, expected in TEST_CASES:
             self._run_test(string, expected)

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -11,10 +11,10 @@ from godot_parser import (
 
 class TestGDSections(unittest.TestCase):
 
-    """ Tests for GD file sections """
+    """Tests for GD file sections"""
 
     def test_header_dunder(self):
-        """ Tests for __magic__ methods on GDSectionHeader """
+        """Tests for __magic__ methods on GDSectionHeader"""
         h = GDSectionHeader("node")
         self.assertEqual(str(h), "[node]")
         self.assertEqual(repr(h), "GDSectionHeader([node])")
@@ -25,7 +25,7 @@ class TestGDSections(unittest.TestCase):
         self.assertNotEqual(h, "[node]")
 
     def test_section_dunder(self):
-        """ Tests for __magic__ methods on GDSection """
+        """Tests for __magic__ methods on GDSection"""
         h = GDSectionHeader("node")
         s = GDSection(h, vframes=10)
         self.assertEqual(str(s), "[node]\nvframes = 10")
@@ -43,7 +43,7 @@ class TestGDSections(unittest.TestCase):
         del s["vframes"]
 
     def test_ext_resource(self):
-        """ Test for GDExtResourceSection """
+        """Test for GDExtResourceSection"""
         s = GDExtResourceSection("res://Other.tscn", type="PackedScene", id=1)
         self.assertEqual(s.path, "res://Other.tscn")
         self.assertEqual(s.type, "PackedScene")
@@ -56,7 +56,7 @@ class TestGDSections(unittest.TestCase):
         self.assertEqual(s.id, 2)
 
     def test_sub_resource(self):
-        """ Test for GDSubResourceSection """
+        """Test for GDSubResourceSection"""
         s = GDSubResourceSection(type="CircleShape2D", id=1)
         self.assertEqual(s.type, "CircleShape2D")
         self.assertEqual(s.id, 1)
@@ -66,7 +66,7 @@ class TestGDSections(unittest.TestCase):
         self.assertEqual(s.id, 2)
 
     def test_node(self):
-        """ Test for GDNodeSection """
+        """Test for GDNodeSection"""
         s = GDNodeSection("Sprite", type="Sprite")
         self.assertIsNone(s.instance)
         self.assertIsNone(s.index)

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -67,10 +67,11 @@ class TestGDSections(unittest.TestCase):
 
     def test_node(self):
         """Test for GDNodeSection"""
-        s = GDNodeSection("Sprite", type="Sprite")
+        s = GDNodeSection("Sprite", type="Sprite", groups=["foo", "bar"])
         self.assertIsNone(s.instance)
         self.assertIsNone(s.index)
         self.assertEqual(s.type, "Sprite")
+        self.assertEqual(s.groups, ["foo", "bar"])
 
         # Setting the instance removes the type
         s.instance = 1
@@ -86,3 +87,7 @@ class TestGDSections(unittest.TestCase):
         self.assertEqual(s.index, 3)
         s.index = None
         self.assertEqual(s.index, None)
+
+        # Setting groups
+        s.groups = ["baz"]
+        self.assertEqual(s.groups, ["baz"])

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -9,10 +9,10 @@ from godot_parser.util import find_project_root, gdpath_to_filepath
 
 class TestTree(unittest.TestCase):
 
-    """ Test the the high-level tree API """
+    """Test the the high-level tree API"""
 
     def test_get_node(self):
-        """ Test for get_node() """
+        """Test for get_node()"""
         scene = GDScene()
         scene.add_node("RootNode")
         scene.add_node("Child", parent=".")
@@ -21,7 +21,7 @@ class TestTree(unittest.TestCase):
         self.assertEqual(node, child)
 
     def test_remove_node(self):
-        """ Test for remove_node() """
+        """Test for remove_node()"""
         scene = GDScene()
         scene.add_node("RootNode")
         scene.add_node("Child", parent=".")
@@ -58,7 +58,7 @@ class TestTree(unittest.TestCase):
         self.assertIsNone(node)
 
     def test_insert_child(self):
-        """ Test for insert_child() """
+        """Test for insert_child()"""
         scene = GDScene()
         scene.add_node("RootNode")
         scene.add_node("Child1", parent=".")
@@ -73,21 +73,21 @@ class TestTree(unittest.TestCase):
         self.assertLess(idx2, idx1)
 
     def test_empty_scene(self):
-        """ Empty scenes should not crash """
+        """Empty scenes should not crash"""
         scene = GDScene()
         with scene.use_tree() as tree:
             n = tree.get_node("Any")
             self.assertIsNone(n)
 
     def test_get_missing_node(self):
-        """ get_node on missing node should return None """
+        """get_node on missing node should return None"""
         scene = GDScene()
         scene.add_node("RootNode")
         node = scene.get_node("Foo/Bar/Baz")
         self.assertIsNone(node)
 
     def test_properties(self):
-        """ Test for changing properties on a node """
+        """Test for changing properties on a node"""
         scene = GDScene()
         scene.add_node("RootNode")
         with scene.use_tree() as tree:
@@ -101,7 +101,7 @@ class TestTree(unittest.TestCase):
         self.assertEqual(child["vframes"], 10)
 
     def test_dunder(self):
-        """ Test __magic__ methods on Node """
+        """Test __magic__ methods on Node"""
         n = Node("Player")
         self.assertEqual(str(n), "Node(Player)")
         self.assertEqual(repr(n), "Node(Player)")
@@ -109,7 +109,7 @@ class TestTree(unittest.TestCase):
 
 class TestInheritedScenes(unittest.TestCase):
 
-    """ Test the the high-level tree API for inherited scenes """
+    """Test the the high-level tree API for inherited scenes"""
 
     project_dir = None
     root_scene = None
@@ -172,7 +172,7 @@ flip_h = true
             shutil.rmtree(cls.project_dir)
 
     def test_load_inherited(self):
-        """ Can load an inherited scene and read the nodes """
+        """Can load an inherited scene and read the nodes"""
         scene = GDScene.load(self.leaf_scene)
         with scene.use_tree() as tree:
             node = tree.get_node("Health/LifeBar")
@@ -180,7 +180,7 @@ flip_h = true
             self.assertEqual(node.type, "TextureProgress")
 
     def test_add_new_nodes(self):
-        """ Can add new nodes to an inherited scene """
+        """Can add new nodes to an inherited scene"""
         scene = GDScene.load(self.leaf_scene)
         with scene.use_tree() as tree:
             tree.get_node("Health/LifeBar")
@@ -197,7 +197,7 @@ flip_h = true
         self.assertEqual(found.index, 3)
 
     def test_cannot_remove(self):
-        """ Cannot remove inherited nodes """
+        """Cannot remove inherited nodes"""
         scene = GDScene.load(self.leaf_scene)
         with scene.use_tree() as tree:
             node = tree.get_node("Health")
@@ -208,7 +208,7 @@ flip_h = true
             )
 
     def test_cannot_mutate(self):
-        """ Cannot change the name/type/instance of inherited nodes """
+        """Cannot change the name/type/instance of inherited nodes"""
         scene = GDScene.load(self.leaf_scene)
 
         def change_name(x):
@@ -227,7 +227,7 @@ flip_h = true
             self.assertRaises(TreeMutationException, lambda: change_instance(node))
 
     def test_inherit_properties(self):
-        """ Inherited nodes inherit properties """
+        """Inherited nodes inherit properties"""
         scene = GDScene.load(self.leaf_scene)
         with scene.use_tree() as tree:
             self.assertEqual(tree.root["shape"], SubResource(1))
@@ -237,7 +237,7 @@ flip_h = true
             self.assertRaises(KeyError, lambda: tree.root["missing"])
 
     def test_unchanged_sections(self):
-        """ Inherited nodes do not appear in sections """
+        """Inherited nodes do not appear in sections"""
         scene = GDScene.load(self.leaf_scene)
         num_nodes = len(scene.get_nodes())
         self.assertEqual(num_nodes, 2)
@@ -249,7 +249,7 @@ flip_h = true
         self.assertEqual(num_nodes, 2)
 
     def test_overwrite_sections(self):
-        """ Inherited nodes appear in sections if we change their configuration """
+        """Inherited nodes appear in sections if we change their configuration"""
         scene = GDScene.load(self.leaf_scene)
         with scene.use_tree() as tree:
             node = tree.get_node("Health/LifeBar")
@@ -260,7 +260,7 @@ flip_h = true
         self.assertIsNotNone(node)
 
     def test_disappear_sections(self):
-        """ Inherited nodes are removed from sections if we change their configuration to match parent """
+        """Inherited nodes are removed from sections if we change their configuration to match parent"""
         scene = GDScene.load(self.leaf_scene)
         with scene.use_tree() as tree:
             sprite = tree.get_node("Sprite")
@@ -270,7 +270,7 @@ flip_h = true
         self.assertIsNone(node)
 
     def test_find_project_root(self):
-        """ Can find project root even if deep in folder """
+        """Can find project root even if deep in folder"""
         os.mkdir(os.path.join(self.project_dir, "Dir1"))
         nested = os.path.join(self.project_dir, "Dir1", "Dir2")
         os.mkdir(nested)
@@ -278,20 +278,20 @@ flip_h = true
         self.assertEqual(root, self.project_dir)
 
     def test_invalid_tree(self):
-        """ Raise exception when tree is invalid """
+        """Raise exception when tree is invalid"""
         scene = GDScene()
         scene.add_node("RootNode")
         scene.add_node("Child", parent="Missing")
         self.assertRaises(TreeMutationException, lambda: scene.get_node("Child"))
 
     def test_missing_root(self):
-        """ Raise exception when GDScene is inherited but missing project_root """
+        """Raise exception when GDScene is inherited but missing project_root"""
         scene = GDScene()
         scene.add_ext_node("Root", 1)
         self.assertRaises(RuntimeError, lambda: scene.get_node("Root"))
 
     def test_missing_ext_resource(self):
-        """ Raise exception when GDScene is inherited but ext_resource is missing """
+        """Raise exception when GDScene is inherited but ext_resource is missing"""
         scene = GDScene.load(self.leaf_scene)
         for section in scene.get_ext_resources():
             scene.remove_section(section)
@@ -300,13 +300,13 @@ flip_h = true
 
 class TestUtil(unittest.TestCase):
 
-    """ Tests for util """
+    """Tests for util"""
 
     def test_bad_gdpath(self):
-        """ Raise exception on bad gdpath """
+        """Raise exception on bad gdpath"""
         self.assertRaises(ValueError, lambda: gdpath_to_filepath("/", "foobar"))
 
     def test_no_project(self):
-        """ If no Godot project is found, return None """
+        """If no Godot project is found, return None"""
         root = find_project_root(tempfile.gettempdir())
         self.assertIsNone(root)


### PR DESCRIPTION
Hi!

First of all thank you so much for making this project! It's so far saved me quite a bit of time on my own Godot project.

However, my project requires that the nodes that I'm generating have groups (this is normally done in Godot by manually assigning a node to a group in the inspector). It looks like groups was on your todo-list based on the code comments, so I tried my best to implement them. Implementing these changes locally has allowed me to export nodes with groups.

I'm relatively new to Python development and I wasn't sure how to test my changes, so please let me know if this is an acceptable change, and if it's not I would appreciate some direction to make it so.