### PR TITLE
Include py.typed file in distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,10 @@ packages = find:
 install_requires =
     pyparsing>=3
 
+[options.package_data]
+godot_parser =
+    py.typed
+
 [options.packages.find]
 exclude = tests
 


### PR DESCRIPTION
Makes sure that the py.typed file is included when packaging or installing the library.

This is needed in order for users of the library to leverage the type annotations (ex. via mypy).