### PR TITLE
Parser updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 .pyre/
 
 .direnv/
+
+#PyCharm
+.idea

--- a/godot_parser/files.py
+++ b/godot_parser/files.py
@@ -304,7 +304,7 @@ class GDFile(object):
     @classmethod
     def parse(cls: Type[GDFileType], contents: str) -> GDFileType:
         """Parse the contents of a Godot file"""
-        return cls.from_parser(scene_file.parse_string(contents, parseAll=True))
+        return cls.from_parser(scene_file.parse_string(contents, parse_all=True))
 
     @classmethod
     def load(cls: Type[GDFileType], filepath: str) -> GDFileType:

--- a/godot_parser/files.py
+++ b/godot_parser/files.py
@@ -356,9 +356,9 @@ class GDFile(object):
 class GDCommonFile(GDFile):
     """Base class with common application logic for all Godot file types"""
 
-    def __init__(self, name: str, *sections: GDSection, _format:int=2) -> None:
+    def __init__(self, name: str, *sections: GDSection) -> None:
         super().__init__(
-            GDSection(GDSectionHeader(name, load_steps=1, format=_format)), *sections
+            GDSection(GDSectionHeader(name, load_steps=1, format=2)), *sections
         )
         self.load_steps = (
             1 + len(self.get_ext_resources()) + len(self.get_sub_resources())
@@ -449,10 +449,10 @@ class GDCommonFile(GDFile):
 
 
 class GDScene(GDCommonFile):
-    def __init__(self, *sections: GDSection, _format: int = 2) -> None:
-        super().__init__("gd_scene", *sections, _format = _format)
+    def __init__(self, *sections: GDSection) -> None:
+        super().__init__("gd_scene", *sections)
 
 
 class GDResource(GDCommonFile):
-    def __init__(self, *sections: GDSection, _format: int = 2) -> None:
-        super().__init__("gd_resource", *sections, _format = _format)
+    def __init__(self, *sections: GDSection) -> None:
+        super().__init__("gd_resource", *sections)

--- a/godot_parser/files.py
+++ b/godot_parser/files.py
@@ -304,7 +304,7 @@ class GDFile(object):
     @classmethod
     def parse(cls: Type[GDFileType], contents: str) -> GDFileType:
         """Parse the contents of a Godot file"""
-        return cls.from_parser(scene_file.parse_string(contents, parse_all=True))
+        return cls.from_parser(scene_file.parse_with_tabs().parse_string(contents, parse_all=True))
 
     @classmethod
     def load(cls: Type[GDFileType], filepath: str) -> GDFileType:

--- a/godot_parser/files.py
+++ b/godot_parser/files.py
@@ -356,9 +356,9 @@ class GDFile(object):
 class GDCommonFile(GDFile):
     """Base class with common application logic for all Godot file types"""
 
-    def __init__(self, name: str, *sections: GDSection) -> None:
+    def __init__(self, name: str, *sections: GDSection, _format:int=2) -> None:
         super().__init__(
-            GDSection(GDSectionHeader(name, load_steps=1, format=2)), *sections
+            GDSection(GDSectionHeader(name, load_steps=1, format=_format)), *sections
         )
         self.load_steps = (
             1 + len(self.get_ext_resources()) + len(self.get_sub_resources())
@@ -449,10 +449,10 @@ class GDCommonFile(GDFile):
 
 
 class GDScene(GDCommonFile):
-    def __init__(self, *sections: GDSection) -> None:
-        super().__init__("gd_scene", *sections)
+    def __init__(self, *sections: GDSection, _format: int = 2) -> None:
+        super().__init__("gd_scene", *sections, _format = _format)
 
 
 class GDResource(GDCommonFile):
-    def __init__(self, *sections: GDSection) -> None:
-        super().__init__("gd_resource", *sections)
+    def __init__(self, *sections: GDSection, _format: int = 2) -> None:
+        super().__init__("gd_resource", *sections, _format = _format)

--- a/godot_parser/objects.py
+++ b/godot_parser/objects.py
@@ -14,6 +14,7 @@ __all__ = [
     "ExtResource",
     "SubResource",
     "StringName",
+    "TypedDictionary",
 ]
 
 GD_OBJECT_REGISTRY = {}
@@ -71,6 +72,9 @@ class GDObject(metaclass=GDObjectMeta):
 
     def __ne__(self, other) -> bool:
         return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(frozenset((self.name,*self.args)))
 
 
 class Vector2(GDObject):
@@ -247,6 +251,49 @@ class SubResource(GDObject):
         """Setter for id"""
         self.args[0] = id
 
+
+class TypedDictionary():
+    def __init__(self, key_type, value_type, dict_) -> None:
+        self.name = "Dictionary"
+        self.key_type = key_type
+        self.value_type = value_type
+        self.dict_ = dict_
+
+    @classmethod
+    def WithCustomName(cls: Type[TypedDictionary], name, key_type, value_type, dict_) -> TypedDictionary:
+        custom_dict_ = TypedDictionary(key_type, value_type, dict_)
+        custom_dict_.name = name
+        return custom_dict_
+
+    @classmethod
+    def from_parser(cls: Type[TypedDictionary], parse_result) -> TypedDictionary:
+        return TypedDictionary.WithCustomName(*parse_result)
+
+    def __str__(self) -> str:
+        return "%s[%s, %s](%s)" % (
+            self.name,
+            self.key_type,
+            self.value_type,
+            stringify_object(self.dict_)
+        )
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, TypedDictionary):
+            return False
+        return self.name == other.name and \
+            self.key_type == other.key_type and \
+            self.value_type == other.value_type and \
+            self.dict_ == other.dict_
+
+    def __ne__(self, other) -> bool:
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(frozenset((self.name,self.key_type,self.value_type,self.dict_)))
+
 class StringName():
     def __init__(self, str) -> None:
         self.str = str
@@ -268,3 +315,6 @@ class StringName():
 
     def __ne__(self, other) -> bool:
         return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self.str)

--- a/godot_parser/objects.py
+++ b/godot_parser/objects.py
@@ -56,7 +56,7 @@ class GDObject(metaclass=GDObjectMeta):
         return factory(*parse_result[1:])
 
     def __str__(self) -> str:
-        return "%s( %s )" % (
+        return "%s(%s)" % (
             self.name,
             ", ".join([stringify_object(v) for v in self.args]),
         )

--- a/godot_parser/objects.py
+++ b/godot_parser/objects.py
@@ -256,9 +256,7 @@ class StringName():
         return StringName(parse_result[0])
 
     def __str__(self) -> str:
-        return "&\"%s\"" % (
-            self.str,
-        )
+        return "&" + stringify_object(self.str)
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/godot_parser/objects.py
+++ b/godot_parser/objects.py
@@ -14,6 +14,7 @@ __all__ = [
     "ExtResource",
     "SubResource",
     "StringName",
+    "TypedArray",
     "TypedDictionary",
 ]
 
@@ -252,6 +253,46 @@ class SubResource(GDObject):
         self.args[0] = id
 
 
+class TypedArray():
+    def __init__(self, type, list_) -> None:
+        self.name = "Array"
+        self.type = type
+        self.list_ = list_
+
+    @classmethod
+    def WithCustomName(cls: Type[TypedArray], name, type, list_) -> TypedArray:
+        custom_array = TypedArray(type, list_)
+        custom_array.name = name
+        return custom_array
+
+    @classmethod
+    def from_parser(cls: Type[TypedArray], parse_result) -> TypedArray:
+        return TypedArray.WithCustomName(*parse_result)
+
+    def __str__(self) -> str:
+        return "%s[%s](%s)" % (
+            self.name,
+            self.type,
+            stringify_object(self.list_)
+        )
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, TypedArray):
+            return False
+        return self.name == other.name and \
+            self.type == other.type and \
+            self.list_ == other.list_
+
+    def __ne__(self, other) -> bool:
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(frozenset((self.name,self.type,self.list_)))
+
+
 class TypedDictionary():
     def __init__(self, key_type, value_type, dict_) -> None:
         self.name = "Dictionary"
@@ -261,9 +302,9 @@ class TypedDictionary():
 
     @classmethod
     def WithCustomName(cls: Type[TypedDictionary], name, key_type, value_type, dict_) -> TypedDictionary:
-        custom_dict_ = TypedDictionary(key_type, value_type, dict_)
-        custom_dict_.name = name
-        return custom_dict_
+        custom_dict = TypedDictionary(key_type, value_type, dict_)
+        custom_dict.name = name
+        return custom_dict
 
     @classmethod
     def from_parser(cls: Type[TypedDictionary], parse_result) -> TypedDictionary:

--- a/godot_parser/objects.py
+++ b/godot_parser/objects.py
@@ -13,6 +13,7 @@ __all__ = [
     "NodePath",
     "ExtResource",
     "SubResource",
+    "StringName",
 ]
 
 GD_OBJECT_REGISTRY = {}
@@ -245,3 +246,27 @@ class SubResource(GDObject):
     def id(self, id: int) -> None:
         """Setter for id"""
         self.args[0] = id
+
+class StringName():
+    def __init__(self, str) -> None:
+        self.str = str
+
+    @classmethod
+    def from_parser(cls: Type[StringName], parse_result) -> StringName:
+        return StringName(parse_result[0])
+
+    def __str__(self) -> str:
+        return "&\"%s\"" % (
+            self.str,
+        )
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, StringName):
+            return False
+        return self.str == other.str
+
+    def __ne__(self, other) -> bool:
+        return not self.__eq__(other)

--- a/godot_parser/objects.py
+++ b/godot_parser/objects.py
@@ -262,13 +262,13 @@ class TypedArray():
         self.list_ = list_
 
     @classmethod
-    def WithCustomName(cls: Type[TypedArrayType], name, type, list_) -> TypedArrayType:
+    def WithCustomName(cls: Type[TypedArrayType], name, type, list_) -> "TypedArray":
         custom_array = TypedArray(type, list_)
         custom_array.name = name
         return custom_array
 
     @classmethod
-    def from_parser(cls: Type[TypedArrayType], parse_result) -> TypedArrayType:
+    def from_parser(cls: Type[TypedArrayType], parse_result) -> "TypedArray":
         return TypedArray.WithCustomName(*parse_result)
 
     def __str__(self) -> str:
@@ -305,13 +305,13 @@ class TypedDictionary():
         self.dict_ = dict_
 
     @classmethod
-    def WithCustomName(cls: Type[TypedDictionaryType], name, key_type, value_type, dict_) -> TypedDictionaryType:
+    def WithCustomName(cls: Type[TypedDictionaryType], name, key_type, value_type, dict_) -> "TypedDictionary":
         custom_dict = TypedDictionary(key_type, value_type, dict_)
         custom_dict.name = name
         return custom_dict
 
     @classmethod
-    def from_parser(cls: Type[TypedDictionaryType], parse_result) -> TypedDictionaryType:
+    def from_parser(cls: Type[TypedDictionaryType], parse_result) -> "TypedDictionary":
         return TypedDictionary.WithCustomName(*parse_result)
 
     def __str__(self) -> str:
@@ -346,7 +346,7 @@ class StringName():
         self.str = str
 
     @classmethod
-    def from_parser(cls: Type[StringNameType], parse_result) -> StringNameType:
+    def from_parser(cls: Type[StringNameType], parse_result) -> "StringName":
         return StringName(parse_result[0])
 
     def __str__(self) -> str:

--- a/godot_parser/objects.py
+++ b/godot_parser/objects.py
@@ -253,6 +253,8 @@ class SubResource(GDObject):
         self.args[0] = id
 
 
+TypedArrayType = TypeVar("TypedArrayType", bound="TypedArray")
+
 class TypedArray():
     def __init__(self, type, list_) -> None:
         self.name = "Array"
@@ -260,13 +262,13 @@ class TypedArray():
         self.list_ = list_
 
     @classmethod
-    def WithCustomName(cls: Type[TypedArray], name, type, list_) -> TypedArray:
+    def WithCustomName(cls: Type[TypedArrayType], name, type, list_) -> TypedArrayType:
         custom_array = TypedArray(type, list_)
         custom_array.name = name
         return custom_array
 
     @classmethod
-    def from_parser(cls: Type[TypedArray], parse_result) -> TypedArray:
+    def from_parser(cls: Type[TypedArrayType], parse_result) -> TypedArrayType:
         return TypedArray.WithCustomName(*parse_result)
 
     def __str__(self) -> str:
@@ -293,6 +295,8 @@ class TypedArray():
         return hash(frozenset((self.name,self.type,self.list_)))
 
 
+TypedDictionaryType = TypeVar("TypedDictionaryType", bound="TypedDictionary")
+
 class TypedDictionary():
     def __init__(self, key_type, value_type, dict_) -> None:
         self.name = "Dictionary"
@@ -301,13 +305,13 @@ class TypedDictionary():
         self.dict_ = dict_
 
     @classmethod
-    def WithCustomName(cls: Type[TypedDictionary], name, key_type, value_type, dict_) -> TypedDictionary:
+    def WithCustomName(cls: Type[TypedDictionaryType], name, key_type, value_type, dict_) -> TypedDictionaryType:
         custom_dict = TypedDictionary(key_type, value_type, dict_)
         custom_dict.name = name
         return custom_dict
 
     @classmethod
-    def from_parser(cls: Type[TypedDictionary], parse_result) -> TypedDictionary:
+    def from_parser(cls: Type[TypedDictionaryType], parse_result) -> TypedDictionaryType:
         return TypedDictionary.WithCustomName(*parse_result)
 
     def __str__(self) -> str:
@@ -335,12 +339,14 @@ class TypedDictionary():
     def __hash__(self):
         return hash(frozenset((self.name,self.key_type,self.value_type,self.dict_)))
 
+StringNameType = TypeVar("StringNameType", bound="StringName")
+
 class StringName():
     def __init__(self, str) -> None:
         self.str = str
 
     @classmethod
-    def from_parser(cls: Type[StringName], parse_result) -> StringName:
+    def from_parser(cls: Type[StringNameType], parse_result) -> StringNameType:
         return StringName(parse_result[0])
 
     def __str__(self) -> str:

--- a/godot_parser/sections.py
+++ b/godot_parser/sections.py
@@ -137,7 +137,7 @@ class GDSection(metaclass=GDSectionMeta):
         if self.properties:
             ret += "\n" + "\n".join(
                 [
-                    "%s = %s" % (k, stringify_object(v))
+                    "%s = %s" % ("\""+k+"\"" if ' ' in k else k, stringify_object(v))
                     for k, v in self.properties.items()
                 ]
             )

--- a/godot_parser/util.py
+++ b/godot_parser/util.py
@@ -23,7 +23,7 @@ def stringify_object(value):
             + "\n}"
         )
     elif isinstance(value, list):
-        return "[ " + ", ".join([stringify_object(v) for v in value]) + " ]"
+        return "[" + ", ".join([stringify_object(v) for v in value]) + "]"
     else:
         return str(value)
 

--- a/godot_parser/util.py
+++ b/godot_parser/util.py
@@ -11,7 +11,7 @@ def stringify_object(value):
         return "null"
     elif isinstance(value, str):
         #return json.dumps(value, ensure_ascii=False)
-        return "\"%s\"" % value.replace("\"", "\\\"")
+        return "\"%s\"" % value.replace("\\","\\\\").replace("\"", "\\\"")
     elif isinstance(value, bool):
         return "true" if value else "false"
     elif isinstance(value, dict):

--- a/godot_parser/util.py
+++ b/godot_parser/util.py
@@ -10,7 +10,8 @@ def stringify_object(value):
     if value is None:
         return "null"
     elif isinstance(value, str):
-        return json.dumps(value, ensure_ascii=False)
+        #return json.dumps(value, ensure_ascii=False)
+        return "\"%s\"" % value.replace("\"", "\\\"")
     elif isinstance(value, bool):
         return "true" if value else "false"
     elif isinstance(value, dict):

--- a/godot_parser/util.py
+++ b/godot_parser/util.py
@@ -17,7 +17,7 @@ def stringify_object(value):
         return (
             "{\n"
             + ",\n".join(
-                ['"%s": %s' % (k, stringify_object(v)) for k, v in value.items()]
+                ['%s: %s' % (stringify_object(k), stringify_object(v)) for k, v in value.items()]
             )
             + "\n}"
         )

--- a/godot_parser/util.py
+++ b/godot_parser/util.py
@@ -10,8 +10,7 @@ def stringify_object(value):
     if value is None:
         return "null"
     elif isinstance(value, str):
-        #return json.dumps(value, ensure_ascii=False)
-        return "\"%s\"" % value.replace("\\","\\\\").replace("\"", "\\\"")
+        return json.dumps(value, ensure_ascii=False)
     elif isinstance(value, bool):
         return "true" if value else "false"
     elif isinstance(value, dict):

--- a/godot_parser/util.py
+++ b/godot_parser/util.py
@@ -15,6 +15,8 @@ def stringify_object(value):
     elif isinstance(value, bool):
         return "true" if value else "false"
     elif isinstance(value, dict):
+        if len(value) == 0:
+            return "{}"
         return (
             "{\n"
             + ",\n".join(

--- a/godot_parser/values.py
+++ b/godot_parser/values.py
@@ -14,7 +14,7 @@ from pyparsing import (
     common,
 )
 
-from .objects import GDObject
+from .objects import GDObject, StringName
 
 boolean = (
     (Keyword("true") | Keyword("false"))
@@ -24,9 +24,14 @@ boolean = (
 
 null = Keyword("null").set_parse_action(lambda _: [None])
 
+_string = QuotedString('"', escChar="\\", multiline=True).set_name("string")
+
+_string_name = (
+    Suppress('&') + _string
+).set_name("string_name").set_parse_action(StringName.from_parser)
 
 primitive = (
-    null | QuotedString('"', escChar="\\", multiline=True) | boolean | common.number
+    null | _string | _string_name | boolean | common.number
 )
 value = Forward()
 

--- a/godot_parser/values.py
+++ b/godot_parser/values.py
@@ -14,7 +14,7 @@ from pyparsing import (
     common,
 )
 
-from .objects import GDObject, StringName, TypedDictionary
+from .objects import GDObject, StringName, TypedDictionary, TypedArray
 
 boolean = (
     (Keyword("true") | Keyword("false"))
@@ -53,6 +53,17 @@ list_ = (
     .set_name("list")
     .set_parse_action(lambda p: p.as_list())
 )
+
+# Array[StringName]([&"a", &"b", &"c"])
+typed_list = (
+    Word(alphas, alphanums).set_results_name("object_name") +
+    (
+        Suppress("[")
+        + obj_type.set_results_name("type")
+        + Suppress("]")
+    ) + Suppress("(") + list_ + Suppress(")")
+).set_parse_action(TypedArray.from_parser)
+
 key_val = Group(value + Suppress(":") + value)
 
 # {
@@ -64,6 +75,9 @@ dict_ = (
     .set_parse_action(lambda d: {k: v for k, v in d})
 )
 
+# Dictionary[StringName,ExtResource("1_qwert")]({
+# &"_edit_use_anchors_": ExtResource("2_testt")
+# })
 typed_dict = (
     Word(alphas, alphanums).set_results_name("object_name") +
     (
@@ -77,4 +91,4 @@ typed_dict = (
 
 # Exports
 
-value <<= list_ | dict_ | typed_dict | obj_ | primitive
+value <<= list_ | typed_list | dict_ | typed_dict | obj_ | primitive

--- a/test_parse_files.py
+++ b/test_parse_files.py
@@ -8,7 +8,7 @@ from itertools import zip_longest
 from godot_parser import load, parse
 
 # Regex to detect all whitespaces not between quotes
-line_normalizer_re = re.compile('\s+(?=((\\[\\"]|[^\\"])*"(\\[\\"]|[^\\"])*")*(\\[\\"]|[^\\"])*$)')
+line_normalizer_re = re.compile('\\s+(?=((\\[\\"]|[^\\"])*"(\\[\\"]|[^\\"])*")*(\\[\\"]|[^\\"])*$)')
 
 def _parse_and_test_file(filename: str) -> bool:
     print("Parsing %s" % filename)

--- a/test_parse_files.py
+++ b/test_parse_files.py
@@ -1,58 +1,102 @@
 #!/usr/bin/env python
 import argparse
 import os
-import sys
 import re
-from itertools import zip_longest
+import io
+import sys
+import traceback
+import difflib
 
 from godot_parser import load, parse
 
-# Regex to detect all whitespaces not between quotes
-line_normalizer_re = re.compile('\\s+(?=((\\[\\"]|[^\\"])*"(\\[\\"]|[^\\"])*")*(\\[\\"]|[^\\"])*$)')
+# Regex to detect space sequences
+space_re = re.compile(r" +")
+# Regex to detect all spaces not surrounded by alphanumeric characters
+line_normalizer_re = re.compile(r"(?<=\W) +| +(?=\W)")
+# Regex to detect quotes and possible escape sequences
+find_quote_re = re.compile(r"(\\*\")")
 
-def _parse_and_test_file(filename: str) -> bool:
-    print("Parsing %s" % filename)
-    with open(filename, "r") as ifile:
-        contents = ifile.read()
-    try:
-        data = parse(contents)
-    except Exception:
-        print("  Parsing error!")
-        import traceback
+def join_lines_within_quotes(input: list[str]):
+    buffer_list = []
+    lines = []
+    buffer = ""
 
-        traceback.print_exc()
-        return False
+    for part in input:
+        # Find all quotes that are not escaped
+        # " is not escaped. \" is escaped. \\" is not escaped as \\ becomes \, leaving the quote unescaped
+        read_pos = 0
+        for match in find_quote_re.finditer(part):
+            span = match.span()
+            match_text = part[span[0]:span[1]]
+            buffer += part[read_pos:span[1]]
+            read_pos = span[1]
+            if len(match_text)%2 == 1:
+                buffer_list.append(buffer)
+                buffer = ""
+        buffer += part[read_pos:]
 
-    f = load(filename)
-    with f.use_tree() as tree:
-        pass
+        if (len(buffer_list) % 2 == 0) and buffer:
+            buffer_list.append(buffer)
+            buffer = ""
 
-    data_lines = [line_normalizer_re.sub("",l) for l in str(data).split("\n") if l]
-    content_lines = [line_normalizer_re.sub("",l) for l in contents.split("\n") if l]
-    if data_lines != content_lines:
-        print("  Error!")
-        max_len = max([len(l) for l in content_lines])
-        if max_len < 100:
-            for orig, parsed in zip_longest(content_lines, data_lines, fillvalue=""):
-                c = " " if orig == parsed else "x"
-                print("%s <%s> %s" % (orig.ljust(max_len), c, parsed))
+        if buffer:
+            buffer += "\n"
         else:
-            for orig, parsed in zip_longest(
-                content_lines, data_lines, fillvalue="----EMPTY----"
-            ):
-                c = "    " if orig == parsed else "XXX)"
-                print("%s\n%s%s" % (orig, c, parsed))
+            for i in range(len(buffer_list)):
+                if i%2 == 0:
+                    buffer_list[i] = space_re.sub(" ", buffer_list[i])
+                    buffer_list[i] = line_normalizer_re.sub("", buffer_list[i])
+            lines.append("".join(buffer_list) + "\n")
+            buffer_list = []
+            buffer = ""
+
+    if buffer:
+        buffer_list.append(buffer)
+    if buffer_list:
+        for i in range(len(buffer_list)):
+            if i % 2 == 0:
+                buffer_list[i] = space_re.sub(" ", buffer_list[i])
+                buffer_list[i] = line_normalizer_re.sub("", buffer_list[i])
+        lines.append("".join(buffer_list) + "\n")
+
+    return lines
+
+
+def _parse_and_test_file(filename: str, verbose: bool) -> bool:
+    if verbose:
+        print("Parsing %s" % filename)
+    with open(filename, "r") as ifile:
+        original_file = ifile.read()
+    try:
+        parsed_file = str(parse(original_file))
+    except Exception:
+        print("! Parsing error on %s" % filename, file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
         return False
-    return True
+
+    original_file = join_lines_within_quotes([l.strip() for l in io.StringIO(original_file).readlines() if l.strip()])
+    parsed_file = join_lines_within_quotes([l.strip() for l in io.StringIO(str(parsed_file)).readlines() if l.strip()])
+
+    diff = difflib.context_diff(original_file, parsed_file, fromfile=filename, tofile="PARSED FILE")
+    diff = ["    "+"\n    ".join(l.strip().split("\n"))+"\n" for l in diff]
+
+    if(len(diff) == 0):
+        return True
+
+    print("! Difference detected on %s" % filename)
+    sys.stdout.writelines(diff)
+    return False
 
 
 def main():
     """Test the parsing of one tscn file or all files in directory"""
     parser = argparse.ArgumentParser(description=main.__doc__)
     parser.add_argument("file_or_dir", help="Parse file or files under this directory")
+    parser.add_argument("--all", action='store_true', help="Tests all files even if one fails")
+    parser.add_argument("--verbose", "-v", action='store_true', help="Prints all file paths as they're parsed")
     args = parser.parse_args()
     if os.path.isfile(args.file_or_dir):
-        _parse_and_test_file(args.file_or_dir)
+        _parse_and_test_file(args.file_or_dir, args.verbose)
     else:
         for root, _dirs, files in os.walk(args.file_or_dir, topdown=False):
             for file in files:
@@ -60,9 +104,9 @@ def main():
                 if ext not in [".tscn", ".tres"]:
                     continue
                 filepath = os.path.join(root, file)
-                if not _parse_and_test_file(filepath):
-                    sys.exit(1)
+                if not _parse_and_test_file(filepath, args.verbose) and not args.all:
+                    return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/test_parse_files.py
+++ b/test_parse_files.py
@@ -1,129 +1,65 @@
 #!/usr/bin/env python
 import argparse
 import os
-import re
-import io
 import sys
-import traceback
-import difflib
+from itertools import zip_longest
 
 from godot_parser import load, parse
 
-# Regex to detect space sequences
-space_re = re.compile(r" +")
-# Regex to detect all spaces not surrounded by alphanumeric characters
-line_normalizer_re = re.compile(r"(?<=\W) +| +(?=\W)")
-# Regex to detect quotes and possible escape sequences
-find_quote_re = re.compile(r"(\\*\")")
 
-def join_lines_within_quotes(input: list[str], unescape: bool):
-    buffer_list = []
-    lines = []
-    buffer = ""
-
-    for part in input:
-        # Find all quotes that are not escaped
-        # " is not escaped. \" is escaped. \\" is not escaped as \\ becomes \, leaving the quote unescaped
-        read_pos = 0
-        for match in find_quote_re.finditer(part):
-            span = match.span()
-            match_text = part[span[0]:span[1]]
-            buffer += part[read_pos:span[1]]
-            read_pos = span[1]
-            if len(match_text)%2 == 1:
-                buffer_list.append(buffer)
-                buffer = ""
-        buffer += part[read_pos:]
-
-        if (len(buffer_list) % 2 == 0) and buffer:
-            buffer_list.append(buffer)
-            buffer = ""
-
-        if buffer:
-            buffer += "\n"
-        else:
-            for i in range(len(buffer_list)):
-                if i%2 == 0:
-                    buffer_list[i] = space_re.sub(" ", buffer_list[i])
-                    buffer_list[i] = line_normalizer_re.sub("", buffer_list[i])
-                elif unescape:
-                    buffer_list[i] = buffer_list[i].encode('latin-1', 'backslashreplace').decode('unicode-escape')
-            lines.append("".join(buffer_list) + "\n")
-            buffer_list = []
-            buffer = ""
-
-    if buffer:
-        buffer_list.append(buffer)
-    if buffer_list:
-        for i in range(len(buffer_list)):
-            if i % 2 == 0:
-                buffer_list[i] = space_re.sub(" ", buffer_list[i])
-                buffer_list[i] = line_normalizer_re.sub("", buffer_list[i])
-            elif unescape:
-                buffer_list[i] = buffer_list[i].encode('latin-1', 'backslashreplace').decode('unicode-escape')
-        lines.append("".join(buffer_list) + "\n")
-
-    return lines
-
-
-def _parse_and_test_file(filename: str, verbose: bool, unescape: bool) -> bool:
-    if verbose:
-        print("Parsing %s" % filename)
+def _parse_and_test_file(filename: str) -> bool:
+    print("Parsing %s" % filename)
     with open(filename, "r") as ifile:
-        original_file = ifile.read()
+        contents = ifile.read()
     try:
-        parsed_file = str(parse(original_file))
+        data = parse(contents)
     except Exception:
-        print("! Parsing error on %s" % filename, file=sys.stderr)
-        traceback.print_exc(file=sys.stderr)
+        print("  Parsing error!")
+        import traceback
+
+        traceback.print_exc()
         return False
 
-    original_file = join_lines_within_quotes(
-        [l.strip() for l in io.StringIO(original_file).readlines() if l.strip()],
-        unescape
-    )
-    parsed_file = join_lines_within_quotes(
-        [l.strip() for l in io.StringIO(str(parsed_file)).readlines() if l.strip()],
-        unescape
-    )
+    f = load(filename)
+    with f.use_tree() as tree:
+        pass
 
-    diff = difflib.context_diff(original_file, parsed_file, fromfile=filename, tofile="PARSED FILE")
-    diff = ["    "+"\n    ".join(l.strip().split("\n"))+"\n" for l in diff]
-
-    if(len(diff) == 0):
-        return True
-
-    print("! Difference detected on %s" % filename)
-    sys.stdout.writelines(diff)
-    return False
+    data_lines = [l for l in str(data).split("\n") if l]
+    content_lines = [l for l in contents.split("\n") if l]
+    if data_lines != content_lines:
+        print("  Error!")
+        max_len = max([len(l) for l in content_lines])
+        if max_len < 100:
+            for orig, parsed in zip_longest(content_lines, data_lines, fillvalue=""):
+                c = " " if orig == parsed else "x"
+                print("%s <%s> %s" % (orig.ljust(max_len), c, parsed))
+        else:
+            for orig, parsed in zip_longest(
+                content_lines, data_lines, fillvalue="----EMPTY----"
+            ):
+                c = "    " if orig == parsed else "XXX)"
+                print("%s\n%s%s" % (orig, c, parsed))
+        return False
+    return True
 
 
 def main():
     """Test the parsing of one tscn file or all files in directory"""
     parser = argparse.ArgumentParser(description=main.__doc__)
     parser.add_argument("file_or_dir", help="Parse file or files under this directory")
-    parser.add_argument("--all", action='store_true', help="Tests all files even if one fails")
-    parser.add_argument("--verbose", "-v", action='store_true', help="Prints all file paths as they're parsed")
-    parser.add_argument("--unescape", action='store_true', help="Attempts to unescape strings before comparison (Godot 4.5+ standard)")
     args = parser.parse_args()
     if os.path.isfile(args.file_or_dir):
-        _parse_and_test_file(args.file_or_dir, args.verbose, args.unescape)
+        _parse_and_test_file(args.file_or_dir)
     else:
-        all_passed = True
         for root, _dirs, files in os.walk(args.file_or_dir, topdown=False):
             for file in files:
                 ext = os.path.splitext(file)[1]
                 if ext not in [".tscn", ".tres"]:
                     continue
                 filepath = os.path.join(root, file)
-                if not _parse_and_test_file(filepath, args.verbose, args.unescape):
-                    all_passed = False
-                    if not args.all:
-                        return 1
-
-        if all_passed:
-            print("All tests passed!")
+                if not _parse_and_test_file(filepath):
+                    sys.exit(1)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/test_parse_files.py
+++ b/test_parse_files.py
@@ -2,10 +2,13 @@
 import argparse
 import os
 import sys
+import re
 from itertools import zip_longest
 
 from godot_parser import load, parse
 
+# Regex to detect all whitespaces not between quotes
+line_normalizer_re = re.compile('\s+(?=((\\[\\"]|[^\\"])*"(\\[\\"]|[^\\"])*")*(\\[\\"]|[^\\"])*$)')
 
 def _parse_and_test_file(filename: str) -> bool:
     print("Parsing %s" % filename)
@@ -24,8 +27,8 @@ def _parse_and_test_file(filename: str) -> bool:
     with f.use_tree() as tree:
         pass
 
-    data_lines = [l for l in str(data).split("\n") if l]
-    content_lines = [l for l in contents.split("\n") if l]
+    data_lines = [line_normalizer_re.sub("",l) for l in str(data).split("\n") if l]
+    content_lines = [line_normalizer_re.sub("",l) for l in contents.split("\n") if l]
     if data_lines != content_lines:
         print("  Error!")
         max_len = max([len(l) for l in content_lines])

--- a/tests/test_gdfile.py
+++ b/tests/test_gdfile.py
@@ -29,7 +29,7 @@ class TestGDFile(unittest.TestCase):
 [resource]
 list = [ 1, 2.0, "string" ]
 map = {
-"key": [ "nested", Vector2( 1, 1 ) ]
+"key": [ "nested", Vector2(1, 1) ]
 }
 empty = null
 escaped = "foo(\\"bar\\")"

--- a/tests/test_gdfile.py
+++ b/tests/test_gdfile.py
@@ -13,7 +13,7 @@ class TestGDFile(unittest.TestCase):
 
     def test_all_data_types(self):
         """Run the parsing test cases"""
-        res = GDResource()
+        res = GDResource(_format = 3)
         res.add_section(
             GDResourceSection(
                 list=[1, 2.0, "string"],
@@ -24,7 +24,7 @@ class TestGDFile(unittest.TestCase):
         )
         self.assertEqual(
             str(res),
-            """[gd_resource load_steps=1 format=2]
+            """[gd_resource load_steps=1 format=3]
 
 [resource]
 list = [ 1, 2.0, "string" ]
@@ -258,7 +258,7 @@ visible = false
                 str_value="\ta\"q\'é'd\"\n",
             )
         )
-        self.assertEqual(str(res), """[gd_resource load_steps=1 format=3]
+        self.assertEqual(str(res), """[gd_resource load_steps=1 format=2]
 
 [resource]
 str_value = "	a\\"q'é'd\\"

--- a/tests/test_gdfile.py
+++ b/tests/test_gdfile.py
@@ -243,8 +243,7 @@ visible = false
         resource["key"] = "value"
         self.assertNotEqual(s1, s2)
 
-
-
+class Godot4Test(unittest.TestCase):
     def test_string_special_characters(self):
         """
         Testing strings with multiple special characters. Currently matching Godot 4.6 behavior

--- a/tests/test_gdfile.py
+++ b/tests/test_gdfile.py
@@ -242,3 +242,25 @@ visible = false
         resource = s1.find_section("resource")
         resource["key"] = "value"
         self.assertNotEqual(s1, s2)
+
+
+
+    def test_string_special_characters(self):
+        """
+        Testing strings with multiple special characters. Currently matching Godot 4.6 behavior
+
+        Tab handling is done by calling parse_with_tabs before parse_string
+        For this reason, this test is being done at a GDFile level, where this method is called upon parsing
+        """
+        res = GDResource()
+        res.add_section(
+            GDResourceSection(
+                str_value="\ta\"q\'é'd\"\n",
+            )
+        )
+        self.assertEqual(str(res), """[gd_resource load_steps=1 format=3]
+
+[resource]
+str_value = "	a\\"q'é'd\\"
+"
+""")

--- a/tests/test_gdfile.py
+++ b/tests/test_gdfile.py
@@ -27,9 +27,9 @@ class TestGDFile(unittest.TestCase):
             """[gd_resource load_steps=1 format=3]
 
 [resource]
-list = [ 1, 2.0, "string" ]
+list = [1, 2.0, "string"]
 map = {
-"key": [ "nested", Vector2(1, 1) ]
+"key": ["nested", Vector2(1, 1)]
 }
 empty = null
 escaped = "foo(\\"bar\\")"

--- a/tests/test_gdfile.py
+++ b/tests/test_gdfile.py
@@ -255,12 +255,13 @@ visible = false
         res = GDResource()
         res.add_section(
             GDResourceSection(
-                str_value="\ta\"q\'é'd\"\n",
+                str_value="\ta\"q\'é'd\"\n\n\\",
             )
         )
         self.assertEqual(str(res), """[gd_resource load_steps=1 format=2]
 
 [resource]
 str_value = "	a\\"q'é'd\\"
-"
+
+\\\\"
 """)

--- a/tests/test_gdfile.py
+++ b/tests/test_gdfile.py
@@ -242,25 +242,3 @@ visible = false
         resource = s1.find_section("resource")
         resource["key"] = "value"
         self.assertNotEqual(s1, s2)
-
-class Godot4Test(unittest.TestCase):
-    def test_string_special_characters(self):
-        """
-        Testing strings with multiple special characters. Currently matching Godot 4.6 behavior
-
-        Tab handling is done by calling parse_with_tabs before parse_string
-        For this reason, this test is being done at a GDFile level, where this method is called upon parsing
-        """
-        res = GDResource()
-        res.add_section(
-            GDResourceSection(
-                str_value="\ta\"q\'é'd\"\n\n\\",
-            )
-        )
-        self.assertEqual(str(res), """[gd_resource load_steps=1 format=2]
-
-[resource]
-str_value = "	a\\"q'é'd\\"
-
-\\\\"
-""")

--- a/tests/test_gdfile.py
+++ b/tests/test_gdfile.py
@@ -13,7 +13,7 @@ class TestGDFile(unittest.TestCase):
 
     def test_all_data_types(self):
         """Run the parsing test cases"""
-        res = GDResource(_format = 3)
+        res = GDResource()
         res.add_section(
             GDResourceSection(
                 list=[1, 2.0, "string"],
@@ -24,7 +24,7 @@ class TestGDFile(unittest.TestCase):
         )
         self.assertEqual(
             str(res),
-            """[gd_resource load_steps=1 format=3]
+            """[gd_resource load_steps=1 format=2]
 
 [resource]
 list = [1, 2.0, "string"]

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,6 +1,6 @@
 import unittest
 
-from godot_parser import Color, ExtResource, NodePath, SubResource, Vector2, Vector3, StringName, GDObject, TypedDictionary
+from godot_parser import Color, ExtResource, NodePath, SubResource, Vector2, Vector3, StringName, GDObject, TypedDictionary, TypedArray
 
 
 class TestGDObjects(unittest.TestCase):
@@ -130,3 +130,19 @@ class TestGDObjects(unittest.TestCase):
         self.assertEqual(repr(td), """Dictionary[StringName, ExtResource("1_qwert")]({
 &"asd": ExtResource("2_qwert")
 })""")
+
+    def test_typed_array(self):
+        """Test for TypedArray"""
+        list1 = [
+            StringName("asd"),
+            StringName("dsa"),
+        ]
+        ta = TypedArray("StringName", list1)
+        self.assertEqual(repr(ta), """Array[StringName]([&"asd", &"dsa"])""")
+
+        list2 = [
+            GDObject("ExtResource", "1_qwert"),
+            GDObject("ExtResource", "2_testt")
+        ]
+        ta = TypedArray("StringName", list2)
+        self.assertEqual(repr(ta), """Array[StringName]([ExtResource("1_qwert"), ExtResource("2_testt")])""")

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,6 +1,6 @@
 import unittest
 
-from godot_parser import Color, ExtResource, NodePath, SubResource, Vector2, Vector3
+from godot_parser import Color, ExtResource, NodePath, SubResource, Vector2, Vector3, StringName
 
 
 class TestGDObjects(unittest.TestCase):
@@ -13,7 +13,7 @@ class TestGDObjects(unittest.TestCase):
         self.assertEqual(v[1], 2)
         self.assertEqual(v.x, 1)
         self.assertEqual(v.y, 2)
-        self.assertEqual(str(v), "Vector2( 1, 2 )")
+        self.assertEqual(str(v), "Vector2(1, 2)")
         v.x = 2
         v.y = 3
         self.assertEqual(v.x, 2)
@@ -32,7 +32,7 @@ class TestGDObjects(unittest.TestCase):
         self.assertEqual(v.x, 1)
         self.assertEqual(v.y, 2)
         self.assertEqual(v.z, 3)
-        self.assertEqual(str(v), "Vector3( 1, 2, 3 )")
+        self.assertEqual(str(v), "Vector3(1, 2, 3)")
         v.x = 2
         v.y = 3
         v.z = 4
@@ -57,7 +57,7 @@ class TestGDObjects(unittest.TestCase):
         self.assertEqual(c.g, 0.2)
         self.assertEqual(c.b, 0.3)
         self.assertEqual(c.a, 0.4)
-        self.assertEqual(str(c), "Color( 0.1, 0.2, 0.3, 0.4 )")
+        self.assertEqual(str(c), "Color(0.1, 0.2, 0.3, 0.4)")
         c.r = 0.2
         c.g = 0.3
         c.b = 0.4
@@ -89,7 +89,7 @@ class TestGDObjects(unittest.TestCase):
         self.assertEqual(r.id, 1)
         r.id = 2
         self.assertEqual(r.id, 2)
-        self.assertEqual(str(r), "ExtResource( 2 )")
+        self.assertEqual(str(r), "ExtResource(2)")
 
     def test_sub_resource(self):
         """Test for SubResource"""
@@ -97,14 +97,26 @@ class TestGDObjects(unittest.TestCase):
         self.assertEqual(r.id, 1)
         r.id = 2
         self.assertEqual(r.id, 2)
-        self.assertEqual(str(r), "SubResource( 2 )")
+        self.assertEqual(str(r), "SubResource(2)")
 
     def test_dunder(self):
         """Test the __magic__ methods on GDObject"""
         v = Vector2(1, 2)
-        self.assertEqual(repr(v), "Vector2( 1, 2 )")
+        self.assertEqual(repr(v), "Vector2(1, 2)")
         v2 = Vector2(1, 2)
         self.assertEqual(v, v2)
         v2.x = 10
         self.assertNotEqual(v, v2)
         self.assertNotEqual(v, (1, 2))
+
+    def test_string_name(self):
+        """Test for StringName"""
+        s = StringName("test")
+        self.assertEqual(repr(s), "&\"test\"")
+        s2 = StringName("test")
+        self.assertEqual(s, s2)
+        s2.str = "bad"
+        self.assertNotEqual(s, s2)
+
+        s = StringName("A \"Quoted test\"")
+        self.assertEqual(repr(s), "&\"A \\\"Quoted test\\\"\"")

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -122,6 +122,7 @@ class TestGDObjects(unittest.TestCase):
         self.assertEqual(repr(s), "&\"A \\\"Quoted test\\\"\"")
 
     def test_typed_dictionary(self):
+        """Test for TypedDictionary"""
         dict1 = {
             StringName("asd"): GDObject("ExtResource", "2_qwert")
         }

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,6 +1,6 @@
 import unittest
 
-from godot_parser import Color, ExtResource, NodePath, SubResource, Vector2, Vector3, StringName
+from godot_parser import Color, ExtResource, NodePath, SubResource, Vector2, Vector3, StringName, GDObject, TypedDictionary
 
 
 class TestGDObjects(unittest.TestCase):
@@ -120,3 +120,12 @@ class TestGDObjects(unittest.TestCase):
 
         s = StringName("A \"Quoted test\"")
         self.assertEqual(repr(s), "&\"A \\\"Quoted test\\\"\"")
+
+    def test_typed_dictionary(self):
+        dict1 = {
+            StringName("asd"): GDObject("ExtResource", "2_qwert")
+        }
+        td = TypedDictionary("StringName", GDObject("ExtResource", "1_qwert"), dict1)
+        self.assertEqual(repr(td), """Dictionary[StringName, ExtResource("1_qwert")]({
+&"asd": ExtResource("2_qwert")
+})""")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -17,6 +17,10 @@ TEST_CASES = [
         GDFile(GDSection(GDSectionHeader("gd_resource", load_steps=5, format=2))),
     ),
     (
+        "[gd_resource format=3]",
+        GDFile(GDSection(GDSectionHeader("gd_resource", format=3))),
+    ),
+    (
         '[ext_resource path="res://Sample.tscn" type="PackedScene" id=1]',
         GDFile(
             GDSection(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,7 @@ import unittest
 
 from pyparsing import ParseException
 
-from godot_parser import GDFile, GDObject, GDSection, GDSectionHeader, Vector2, parse
+from godot_parser import GDFile, GDObject, GDSection, GDSectionHeader, Vector2, StringName, parse
 
 HERE = os.path.dirname(__file__)
 
@@ -106,6 +106,21 @@ TEST_CASES = [
                     "0:0/0": 0,
                     "0:0/0/physics_layer_0/linear_velocity": Vector2(0, 0),
                     "0:0/0/physics_layer_0/angular_velocity": 0.0,
+                }
+            )
+        ),
+    ),
+    (
+      """[sub_resource type="CustomType" id=1]
+      string_value = "String"
+      string_name_value = &"StringName"
+      """  ,
+GDFile(
+            GDSection(
+                GDSectionHeader("sub_resource", type="CustomType", id=1),
+                **{
+                    "string_value": "String",
+                    "string_name_value": StringName("StringName"),
                 }
             )
         ),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -116,8 +116,10 @@ TEST_CASES = [
       string_name_value = &"StringName"
       string_quote = "\\"String\\""
       string_name_quote = &"\\"StringName\\""
+      string_single_quote = "\'String\'"
+      string_name_single_quote = &"\'StringName\'"
       """  ,
-GDFile(
+        GDFile(
             GDSection(
                 GDSectionHeader("sub_resource", type="CustomType", id=1),
                 **{
@@ -125,6 +127,8 @@ GDFile(
                     "string_name_value": StringName("StringName"),
                     "string_quote": "\"String\"",
                     "string_name_quote": StringName("\"StringName\""),
+                    "string_single_quote": "'String'",
+                    "string_name_single_quote": StringName("'StringName'"),
                 }
             )
         ),
@@ -138,7 +142,7 @@ GDFile(
       ExtResource("2_testt"): &"key"
       })
       """  ,
-GDFile(
+        GDFile(
             GDSection(
                 GDSectionHeader("sub_resource", type="CustomType", id=1),
                 **{
@@ -150,6 +154,19 @@ GDFile(
                     {
                         GDObject("ExtResource", "2_testt"): StringName("key")
                     })
+                }
+            )
+        ),
+    ),
+    (
+      """[node name="Label" type="Label" parent="." unique_id=1387035530]
+      text = "\ta\\\"q\\'é'd\\\"\n"
+      """,
+        GDFile(
+            GDSection(
+                GDSectionHeader("node", name="Label", type="Label", parent=".", unique_id=1387035530),
+                **{
+                    "text": "\ta\"q'é'd\"\n"
                 }
             )
         ),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,7 @@ import unittest
 
 from pyparsing import ParseException
 
-from godot_parser import GDFile, GDObject, GDSection, GDSectionHeader, Vector2, StringName, parse
+from godot_parser import GDFile, GDObject, GDSection, GDSectionHeader, Vector2, StringName, parse, TypedDictionary
 
 HERE = os.path.dirname(__file__)
 
@@ -125,6 +125,31 @@ GDFile(
                     "string_name_value": StringName("StringName"),
                     "string_quote": "\"String\"",
                     "string_name_quote": StringName("\"StringName\""),
+                }
+            )
+        ),
+    ),
+    (
+      """[sub_resource type="CustomType" id=1]
+      typed_dict_1 = Dictionary[StringName, ExtResource("1_testt")]({
+      &"key": ExtResource("2_testt")
+      })
+      typed_dict_2 = Dictionary[ExtResource("1_testt"), StringName]({
+      ExtResource("2_testt"): &"key"
+      })
+      """  ,
+GDFile(
+            GDSection(
+                GDSectionHeader("sub_resource", type="CustomType", id=1),
+                **{
+                    "typed_dict_1": TypedDictionary("StringName", GDObject("ExtResource", "1_testt"),
+                    {
+                        StringName("key"): GDObject("ExtResource", "2_testt")
+                    }),
+                    "typed_dict_2": TypedDictionary(GDObject("ExtResource", "1_testt"), "StringName",
+                    {
+                        GDObject("ExtResource", "2_testt"): StringName("key")
+                    })
                 }
             )
         ),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,7 @@ import unittest
 
 from pyparsing import ParseException
 
-from godot_parser import GDFile, GDObject, GDSection, GDSectionHeader, Vector2, StringName, parse, TypedDictionary
+from godot_parser import GDFile, GDObject, GDSection, GDSectionHeader, Vector2, StringName, parse, TypedDictionary, TypedArray
 
 HERE = os.path.dirname(__file__)
 
@@ -158,6 +158,30 @@ TEST_CASES = [
                     {
                         GDObject("ExtResource", "2_testt"): StringName("key")
                     })
+                }
+            )
+        ),
+    ),
+    (
+      """[sub_resource type="CustomType" id=1]
+      typed_array_1 = Array[StringName]([&"a", &"b", &"c"])
+      typed_array_2 = Array[ExtResource("1_typee")]([ExtResource("1_qwert"), ExtResource("2_testt")])
+      """  ,
+        GDFile(
+            GDSection(
+                GDSectionHeader("sub_resource", type="CustomType", id=1),
+                **{
+                    "typed_array_1": TypedArray("StringName",
+                    [
+                        StringName("a"),
+                        StringName("b"),
+                        StringName("c"),
+                    ]),
+                    "typed_array_2": TypedArray(GDObject("ExtResource", "1_typee"),
+                    [
+                        GDObject("ExtResource", "1_qwert"),
+                        GDObject("ExtResource", "2_testt"),
+                    ])
                 }
             )
         ),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -114,6 +114,8 @@ TEST_CASES = [
       """[sub_resource type="CustomType" id=1]
       string_value = "String"
       string_name_value = &"StringName"
+      string_quote = "\\"String\\""
+      string_name_quote = &"\\"StringName\\""
       """  ,
 GDFile(
             GDSection(
@@ -121,6 +123,8 @@ GDFile(
                 **{
                     "string_value": "String",
                     "string_name_value": StringName("StringName"),
+                    "string_quote": "\"String\"",
+                    "string_name_quote": StringName("\"StringName\""),
                 }
             )
         ),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -164,13 +164,13 @@ TEST_CASES = [
     ),
     (
       """[node name="Label" type="Label" parent="." unique_id=1387035530]
-      text = "\ta\\\"q\\'é'd\\\"\n"
+      text = "\ta\\\"q\\'é'd\\\"\n\n\\\\"
       """,
         GDFile(
             GDSection(
                 GDSectionHeader("node", name="Label", type="Label", parent=".", unique_id=1387035530),
                 **{
-                    "text": "\ta\"q'é'd\"\n"
+                    "text": "\ta\"q'é'd\"\n\n\\"
                 }
             )
         ),


### PR DESCRIPTION
This PR contains a series of changes to bring this parser up to date with new additions made to Godot (up to 4.6)

- Adds support for typed Arrays `Array[type]([...])`
- Adds support for typed Dictionaries `Dictionary[key_type,value_type]({...})`
- Adds support for StringNames `&"..."`
- Adjusts string output of some types, removing unnecessary whitespaces and matching how Godot 4.6 saves scenes and resources
- Adds support for all Variant types as dictionary keys, matching what is currently possible with Godot
- Adds tests for all changes listed above

- Supersedes #13 #17 #18