### PR TITLE
String output matching Godot 4.6 behavior

### DIFF
--- a/godot_parser/util.py
+++ b/godot_parser/util.py
@@ -1,6 +1,5 @@
 """Utils"""
 
-import json
 import os
 from typing import Optional
 
@@ -10,7 +9,7 @@ def stringify_object(value):
     if value is None:
         return "null"
     elif isinstance(value, str):
-        return json.dumps(value, ensure_ascii=False)
+        return "\"%s\"" % value.replace("\\","\\\\").replace("\"", "\\\"")
     elif isinstance(value, bool):
         return "true" if value else "false"
     elif isinstance(value, dict):

--- a/tests/test_gdfile.py
+++ b/tests/test_gdfile.py
@@ -242,3 +242,25 @@ visible = false
         resource = s1.find_section("resource")
         resource["key"] = "value"
         self.assertNotEqual(s1, s2)
+
+class Godot4Test(unittest.TestCase):
+    def test_string_special_characters(self):
+        """
+        Testing strings with multiple special characters. Currently matching Godot 4.6 behavior
+
+        Tab handling is done by calling parse_with_tabs before parse_string
+        For this reason, this test is being done at a GDFile level, where this method is called upon parsing
+        """
+        res = GDResource()
+        res.add_section(
+            GDResourceSection(
+                str_value="\ta\"q\'é'd\"\n\n\\",
+            )
+        )
+        self.assertEqual(str(res), """[gd_resource load_steps=1 format=2]
+
+[resource]
+str_value = "	a\\"q'é'd\\"
+
+\\\\"
+""")


### PR DESCRIPTION
- Updates the `stringify_object` function to match the current Godot 4.6 behavior
- Adds a test to test this new behavior

<img width="239" height="199" alt="image" src="https://github.com/user-attachments/assets/b8c7da1c-9962-4bd0-b7e8-df331b9e9748" />
<img width="593" height="135" alt="image" src="https://github.com/user-attachments/assets/f79ccf0d-85a0-4c07-81e3-eda6ee3ddb3d" />

```
   asd\a

	
''s"d " ásd
```

I consider this a finicky change as updating this behavior might mean breaking resources in Godot 3. I could not pinpoint when this change happened, as my own project, which as originally created under Godot 4 already contained a few files with escaped strings, so I assume this changed at some point within the 4.0 development. The good news is that Godot is still able to load escaped strings so I don't think this is a must

On top of it, I also noticed other areas of the parser that would require bigger changes to bring it up to date with Godot 4, the most obvious one being how SubResource and ExtResource now have string ids instead of ints, which could mean updating some methods such as `remove_unused_resources` and `renumber_resource_ids`. 4.6 also removed the `load_steps` parameter

Making all of these changes might require deciding how to support Godot 3 and Godot 4, maybe as different branches, maybe as different classes, I'm not sure

Feel free to leave this PR open or blocked for now, or perhaps merging it to a different branch